### PR TITLE
修正循环依赖和脚本

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@
 include $(TOPDIR)/rules.mk
 
 LUCI_TITLE:=LuCI Support for easymesh
-LUCI_DEPENDS:= +batctl-full +kmod-batman-adv +wpad-mesh-openssl
+LUCI_DEPENDS:= +batctl-full +wpad-mesh-openssl
 PKG_VERSION:=1.2
 
 include $(TOPDIR)/feeds/luci/luci.mk

--- a/luasrc/model/cbi/easymesh.lua
+++ b/luasrc/model/cbi/easymesh.lua
@@ -35,29 +35,4 @@ o = s:option(Value, "key", translate("Key"))
 o.default = "easymesh"
 o:depends("encryption", 1)
 
----- ap_mode
-enable = s:option(Flag, "ap_mode", translate("AP MODE Enable"), translate("Enable or disable AP MODE"))
-enable.default = 0
-enable.rmempty = false
-
-o = s:option(Value, "ipaddr", translate("IPv4-Address"))
-o.default = "192.168.1.10"
-o.datatype = "ip4addr"
-o:depends("ap_mode", 1)
-
-o = s:option(Value, "netmask", translate("IPv4 netmask"))
-o.default = "255.255.255.0"
-o.datatype = "ip4addr"
-o:depends("ap_mode", 1)
-
-o = s:option(Value, "gateway", translate("IPv4 gateway"))
-o.default = "192.168.1.1"
-o.datatype = "ip4addr"
-o:depends("ap_mode", 1)
-
-o = s:option(Value, "dns", translate("Use custom DNS servers"))
-o.default = "192.168.1.1"
-o.datatype = "ip4addr"
-o:depends("ap_mode", 1)
-
 return m

--- a/po/templates/easymesh.pot
+++ b/po/templates/easymesh.pot
@@ -1,20 +1,12 @@
 msgid ""
 msgstr "Content-Type: text/plain; charset=UTF-8"
 
-#: luci-app-easymesh/luasrc/model/cbi/easymesh.lua:39
-msgid "AP MODE Enable"
-msgstr ""
-
 #: luci-app-easymesh/luasrc/controller/easymesh.lua:12
 msgid "EASY MESH"
 msgstr ""
 
 #: luci-app-easymesh/luasrc/model/cbi/easymesh.lua:13
 msgid "Enable"
-msgstr ""
-
-#: luci-app-easymesh/luasrc/model/cbi/easymesh.lua:39
-msgid "Enable or disable AP MODE"
 msgstr ""
 
 #: luci-app-easymesh/luasrc/model/cbi/easymesh.lua:13
@@ -31,18 +23,6 @@ msgstr ""
 
 #: luci-app-easymesh/root/usr/share/rpcd/acl.d/luci-app-easymesh.json:3
 msgid "Grant UCI access for luci-app-easymesh"
-msgstr ""
-
-#: luci-app-easymesh/luasrc/model/cbi/easymesh.lua:53
-msgid "IPv4 gateway"
-msgstr ""
-
-#: luci-app-easymesh/luasrc/model/cbi/easymesh.lua:48
-msgid "IPv4 netmask"
-msgstr ""
-
-#: luci-app-easymesh/luasrc/model/cbi/easymesh.lua:43
-msgid "IPv4-Address"
 msgstr ""
 
 #: luci-app-easymesh/luasrc/model/cbi/easymesh.lua:34
@@ -64,8 +44,4 @@ msgstr ""
 
 #: luci-app-easymesh/luasrc/model/cbi/easymesh.lua:17
 msgid "The radio device which MESH use"
-msgstr ""
-
-#: luci-app-easymesh/luasrc/model/cbi/easymesh.lua:58
-msgid "Use custom DNS servers"
 msgstr ""

--- a/po/zh_Hans/easymesh.po
+++ b/po/zh_Hans/easymesh.po
@@ -1,10 +1,6 @@
 msgid ""
 msgstr "Content-Type: text/plain; charset=UTF-8\n"
 
-#: luci-app-easymesh/luasrc/model/cbi/easymesh.lua:39
-msgid "AP MODE Enable"
-msgstr "启用 AP 模式"
-
 #: luci-app-easymesh/luasrc/controller/easymesh.lua:12
 msgid "EASY MESH"
 msgstr "简单 MESH"
@@ -12,10 +8,6 @@ msgstr "简单 MESH"
 #: luci-app-easymesh/luasrc/model/cbi/easymesh.lua:13
 msgid "Enable"
 msgstr "启用"
-
-#: luci-app-easymesh/luasrc/model/cbi/easymesh.lua:39
-msgid "Enable or disable AP MODE"
-msgstr ""
 
 #: luci-app-easymesh/luasrc/model/cbi/easymesh.lua:13
 msgid "Enable or disable EASY MESH"
@@ -32,18 +24,6 @@ msgstr "基本设置"
 #: luci-app-easymesh/root/usr/share/rpcd/acl.d/luci-app-easymesh.json:3
 msgid "Grant UCI access for luci-app-easymesh"
 msgstr ""
-
-#: luci-app-easymesh/luasrc/model/cbi/easymesh.lua:53
-msgid "IPv4 gateway"
-msgstr "IPv4 网关"
-
-#: luci-app-easymesh/luasrc/model/cbi/easymesh.lua:48
-msgid "IPv4 netmask"
-msgstr "IPv4 子网掩码"
-
-#: luci-app-easymesh/luasrc/model/cbi/easymesh.lua:43
-msgid "IPv4-Address"
-msgstr "IPv4 地址"
 
 #: luci-app-easymesh/luasrc/model/cbi/easymesh.lua:34
 msgid "Key"
@@ -65,7 +45,3 @@ msgstr "设置"
 #: luci-app-easymesh/luasrc/model/cbi/easymesh.lua:17
 msgid "The radio device which MESH use"
 msgstr "使用 MESH 组网的无线设备"
-
-#: luci-app-easymesh/luasrc/model/cbi/easymesh.lua:58
-msgid "Use custom DNS servers"
-msgstr "使用自定义的 DNS 服务器"

--- a/root/etc/init.d/easymesh
+++ b/root/etc/init.d/easymesh
@@ -6,13 +6,7 @@ enable=$(uci get easymesh.config.enabled 2>/dev/null)
 mesh_bat0=$(uci get network.bat0 2>/dev/null)
 mesh_nwi_mesh0=$(uci get network.nwi_mesh0 2>/dev/null)
 mesh_mesh0=$(uci get wireless.mesh0 2>/dev/null)
-ap_mode=$(uci get easymesh.config.ap_mode 2>/dev/null)
 lan=$(uci get network.lan.ifname 2>/dev/null)
-ipaddr=$(uci get easymesh.config.ipaddr 2>/dev/null)
-netmask=$(uci get easymesh.config.netmask 2>/dev/null)
-gateway=$(uci get easymesh.config.gateway 2>/dev/null)
-ap_gateway=$(uci get network.lan.gateway 2>/dev/null)
-dns=$(uci get easymesh.config.dns 2>/dev/null)
 mesh_id=$(uci get easymesh.config.mesh_id 2>/dev/null)
 apRadio=$(uci get easymesh.config.apRadio 2>/dev/null)
 mesh0_apRadio=$(uci get wireless.mesh0.device 2>/dev/null)
@@ -79,39 +73,7 @@ start(){
 			uci commit wireless
 		fi
 
-		if [ "$ap_mode" == 1 ]; then
-			if [ "$ap_gateway" != "$gateway" ]; then
-				uci set network.lan.ipaddr=$ipaddr
-				uci set network.lan.netmask=$netmask
-				uci set network.lan.gateway=$gateway
-				uci add_list network.lan.dns=$dns
-				uci commit network
-
-				uci set dhcp.lan.dynamicdhcp='0'
-				uci delete dhcp.lan.ra
-				uci delete dhcp.lan.dhcpv6
-				uci delete dhcp.lan.ra_management
-				uci commit dhcp
-
-				/etc/init.d/odhcpd stop && /etc/init.d/odhcpd disable
-				/etc/init.d/firewall stop && /etc/init.d/firewall disable
-				/etc/init.d/network restart
-			fi
-		else
-			uci delete network.lan.gateway
-			uci delete network.lan.dns
-			uci commit network
-
-			uci delete dhcp.lan.dynamicdhcp
-			uci commit dhcp
-
-			/etc/init.d/odhcpd enable && /etc/init.d/odhcpd start
-			/etc/init.d/firewall enable && /etc/init.d/firewall start
-			/etc/init.d/network restart
-		fi
-			#batctl add if mesh0
-			#brctl addif br-lan bat0
-			#ifconfig bat0 up
+		/etc/init.d/network restart
 	fi
 }
 
@@ -133,16 +95,7 @@ stop(){
 			uci commit wireless
 		fi
 
-			uci delete network.lan.gateway
-			uci delete network.lan.dns
-			uci commit network
-
-			uci delete dhcp.lan.dynamicdhcp
-			uci commit dhcp
-
-			/etc/init.d/odhcpd enable && /etc/init.d/odhcpd start
-			/etc/init.d/firewall enable && /etc/init.d/firewall start
-			/etc/init.d/network restart
+		/etc/init.d/network restart
 	fi
 }
 

--- a/root/etc/init.d/easymesh
+++ b/root/etc/init.d/easymesh
@@ -19,7 +19,7 @@ mesh0_apRadio=$(uci get wireless.mesh0.device 2>/dev/null)
 encryption=$(uci get easymesh.config.encryption 2>/dev/null)
 key=$(uci get easymesh.config.key 2>/dev/null)
 
-start(){	
+start(){
 	if [ "$enable" == 1 ]; then
 		if [ "$mesh_bat0" != "interface" ]; then
 			uci set network.bat0=interface
@@ -40,7 +40,7 @@ start(){
 			uci set network.bat0.network_coding='0'
 			uci set network.bat0.hop_penalty='30'
 			uci set network.bat0.isolation_mark='0x00000000/0x00000000'
-			
+
 			uci add_list network.lan.ifname='bat0'
 			uci commit network
 		fi
@@ -84,9 +84,9 @@ start(){
 				uci set network.lan.ipaddr=$ipaddr
 				uci set network.lan.netmask=$netmask
 				uci set network.lan.gateway=$gateway
-				uci set network.lan.dns=$dns
+				uci add_list network.lan.dns=$dns
 				uci commit network
-			
+
 				uci set dhcp.lan.dynamicdhcp='0'
 				uci delete dhcp.lan.ra
 				uci delete dhcp.lan.dhcpv6
@@ -110,7 +110,7 @@ start(){
 			/etc/init.d/network restart
 		fi
 			#batctl add if mesh0
-			#brctl addif br-lan bat0 
+			#brctl addif br-lan bat0
 			#ifconfig bat0 up
 	fi
 }


### PR DESCRIPTION
目前我在  openwrt-21.02 分支 make menuconfig 时发生循环依赖问题，因此去除了 kmod-batman-adv。需要进一步调查原因。
编译时手动选择 kmod-batman-adv 模块

脚本中的 uci add network.lan.dns 可能不正确。因为 dns 是个 list ，需要使用 uci add_list 命令。